### PR TITLE
Return error response instead of just HTTP code name

### DIFF
--- a/lib/bitcoin/rpc.rb
+++ b/lib/bitcoin/rpc.rb
@@ -23,10 +23,11 @@ class Bitcoin::RPC
   end
   
   def dispatch(request)
-    respdata = RestClient.post service_url, request.to_post_data
-    response = JSON.parse(respdata)
-    raise Bitcoin::Errors::RPCError, response['error'] if response['error']
-    response['result']
+    RestClient.post(service_url, request.to_post_data) do |respdata, request, result|
+      response = JSON.parse(respdata)
+      raise Bitcoin::Errors::RPCError, response['error'] if response['error']
+      response['result']
+    end
   end
   
   private

--- a/spec/lib/bitcoin/client_spec.rb
+++ b/spec/lib/bitcoin/client_spec.rb
@@ -115,7 +115,7 @@ describe Bitcoin::Client do
       context 'invalid address' do
         it "should produce the expected result" do
           lambda { result('invalid_address', 'message').should }.should \
-            raise_error RestClient::InternalServerError
+            raise_error Bitcoin::Errors::RPCError
         end
       end
     end


### PR DESCRIPTION
This will provide error messages from the RPC API rather than RestClient's internal HTTP error code name format, which is much more helpful for debugging problems.
