### PR TITLE
Add Content-Type: application/json to rest client

### DIFF
--- a/lib/bitcoin/rpc.rb
+++ b/lib/bitcoin/rpc.rb
@@ -6,7 +6,7 @@ class Bitcoin::RPC
     @host, @port = options[:host], options[:port]
     @ssl = options[:ssl]
   end
-  
+
   def credentials
     if @user
       "#{@user}:#{@pass}"
@@ -14,22 +14,22 @@ class Bitcoin::RPC
       nil
     end
   end
-  
+
   def service_url
     url = @ssl ? "https://" : "http://"
     url.concat "#{credentials}@" if c = credentials
     url.concat "#{@host}:#{@port}"
     url
   end
-  
+
   def dispatch(request)
-    RestClient.post(service_url, request.to_post_data) do |respdata, request, result|
+    RestClient.post(service_url, request.to_post_data, content_type: :json) do |respdata, request, result|
       response = JSON.parse(respdata)
       raise Bitcoin::Errors::RPCError, response['error'] if response['error']
       response['result']
     end
   end
-  
+
   private
   def symbolize_keys(hash)
     case hash


### PR DESCRIPTION
Tried to use bitcoin-client with https://blockchain.info/api/json_rpc_api and it kept failing. Turns out the reason is that RestClient uses application/x-www-form-urlencoded by default, which is wrong as we are sending application/json. Apparently blockchain.info is strict about proper content-type.

bitcoind does not seem to care about content-type, so it wouldn't hurt it.
