### PR TITLE
revise RPCError

### DIFF
--- a/lib/bitcoin/errors.rb
+++ b/lib/bitcoin/errors.rb
@@ -1,4 +1,71 @@
 module Bitcoin::Errors
   class RPCError < StandardError
+    attr_reader :code
+    attr_reader :message
+
+    def initialize(code, message)
+      @code = code
+      @message = message
+    end
+
+    def to_s
+      { code: code, message: message }.to_s
+    end
   end
+
+  def self.define_errors(super_klass, errors)
+    @errors ||= {}
+    errors.each do |error_code, name|
+      klass = Class.new(super_klass) { def code; error_code; end }
+      self.const_set(name, klass)
+      @errors[error_code] = klass
+    end
+  end
+
+  def self.dispatch_error(code, message)
+    @errors ||= {}
+    error = @errors[code]
+    return GeneralError if not error
+    return error.new(code, message)
+  end
+
+  class GeneralError < RPCError; end
+  class ClientError < RPCError; end
+  class WalletError < RPCError; def code; -4; end; end
+  class UnknownError < RPCError; end
+
+  define_errors(GeneralError, {
+    -32600 => 'InvalidRequest',
+    -32601 => 'MethodNotFound',
+    -32602 => 'InvalidParams',
+    -32603 => 'InternalError',
+    -32700 => 'ParseError',
+    -1 => 'MiscError',
+    -2 => 'ForbiddenBySafeMode',
+    -3 => 'TypeError',
+    -5 => 'InvalidAddressOrKey',
+    -7 => 'OutOfMemory',
+    -8 => 'InvalidParameter',
+    -20 => 'DatabaseError',
+    -22 => 'DeserializationError',
+    -18 => 'ServerNotStarted',
+  })
+
+  define_errors(ClientError, {
+    -9 => 'ClientNotConnected',
+    -10 => 'ClientInInitialDownload',
+    -23 => 'ClientNodeAlreadyAdded',
+    -24 => 'ClientNodeNotAdded',
+  })
+
+  define_errors(WalletError, {
+    -6 => 'WalletInsufficientFunds',
+    -11 => 'WalletInvalidAccountName',
+    -12 => 'WalletKeypoolRanOut',
+    -13 => 'WalletUnlockNeeded',
+    -14 => 'WalletPassphraseIncorrect',
+    -15 => 'WalletWrongEncState',
+    -16 => 'WalletEncryptionFailed',
+    -17 => 'WalletAlreadyUnlocked',
+  })
 end

--- a/lib/bitcoin/rpc.rb
+++ b/lib/bitcoin/rpc.rb
@@ -25,7 +25,8 @@ class Bitcoin::RPC
   def dispatch(request)
     RestClient.post(service_url, request.to_post_data, content_type: :json) do |respdata, request, result|
       response = JSON.parse(respdata)
-      raise Bitcoin::Errors::RPCError, response['error'] if response['error']
+      error = response['error']
+      raise Bitcoin::Errors.dispatch_error(error['code'], error['message']) if error
       response['result']
     end
   end


### PR DESCRIPTION
currently RPCError is plain StandardError, it would parse the parameter
to string, thus what we get in rescue clause is a string like
"{ \"code\" => -17, \"message\" => \"...\"}", but not a Hash.

after this patch applied, it would easier to extract the error code.
