### PR TITLE
Adding support for getblockhash(index).

### DIFF
--- a/lib/bitcoin/client.rb
+++ b/lib/bitcoin/client.rb
@@ -69,6 +69,11 @@ class Bitcoin::Client
     @api.request 'getblocknumber'
   end
 
+  # Returns hash of block in best-block-chain at <index>; index 0 is the genesis block
+  def getblockhash(index)
+    @api.request 'getblockhash', index
+  end
+
   # Returns the number of connections to other nodes.
   def getconnectioncount
     @api.request 'getconnectioncount'
@@ -240,6 +245,7 @@ class Bitcoin::Client
   alias block_by_count getblockbycount
   alias block_count getblockcount
   alias block_number getblocknumber
+  alias block_hash getblockhash
   alias connection_count getconnectioncount
   alias difficulty getdifficulty
   alias generate? getgenerate

--- a/lib/bitcoin/dsl.rb
+++ b/lib/bitcoin/dsl.rb
@@ -98,6 +98,11 @@ module Bitcoin::DSL
   def getblocknumber
     bitcoin.getblocknumber
   end
+
+  # Returns hash of block in best-block-chain at <index>; index 0 is the genesis block
+  def getblockhash(index)
+    bitcoin.getblockhash index
+  end
   
   # Returns the number of connections to other nodes.
   def getconnectioncount
@@ -243,6 +248,7 @@ module Bitcoin::DSL
   alias block_by_count getblockbycount
   alias block_count getblockcount
   alias block_number getblocknumber
+  alias block_hash getblockhash
   alias connection_count getconnectioncount
   alias difficulty getdifficulty
   alias generate? getgenerate


### PR DESCRIPTION
## Summary

I noticed that your library says

> Provides a Ruby library to the complete Bitcoin JSON-RPC API. Implements all methods listed at https://en.bitcoin.it/wiki/Original_Bitcoin_client/API_Calls_list .

Yet didn't appear to support `getblockhash(index)`. So I forked the library and added it.

Please let me know if you have any questions.
## Donation

I really appreciate the library and donated .01 BTC https://blockchain.info/tx/f0459920f024f5e2b00158fcd78dbec685d8ba6075e6e2ca21001767078efada. Thank you!
